### PR TITLE
(APL-849) Update price for hard copy report #849

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -38,7 +38,7 @@ const formatTypes = [
     id: 1,
     title: 'HARD COPY ONLY',
     subTitle: 'High color and graphics printed format of the report',
-    price: 'N150,000',
+    price: 'N500,000',
     selected: false,
   },
   {


### PR DESCRIPTION
Increased the price of the 'HARD COPY ONLY' report from N150,000 to N500,000. This change reflects the updated pricing strategy for high color and graphics printed formats.